### PR TITLE
Workaround for opencover

### DIFF
--- a/src/MineCase.Algorithm/MineCase.Algorithm.csproj
+++ b/src/MineCase.Algorithm/MineCase.Algorithm.csproj
@@ -5,6 +5,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MineCase.Client.Engine/MineCase.Client.Engine.csproj
+++ b/src/MineCase.Client.Engine/MineCase.Client.Engine.csproj
@@ -7,6 +7,8 @@
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -23,11 +25,6 @@
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='TravisCI|AnyCPU'">
     <DocumentationFile>bin\Release\net46\MineCase.Client.Engine.xml</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MineCase.Client.Scripts/MineCase.Client.Scripts.csproj
+++ b/src/MineCase.Client.Scripts/MineCase.Client.Scripts.csproj
@@ -8,9 +8,6 @@
     <LangVersion>latest</LangVersion>
     <PackageTargetFallback>portable-net45+win8+wpa81</PackageTargetFallback>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/src/MineCase.Core/MineCase.Core.csproj
+++ b/src/MineCase.Core/MineCase.Core.csproj
@@ -7,6 +7,8 @@
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <AssemblyName>MineCase.Core</AssemblyName>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'TravisCI'">
@@ -15,11 +17,6 @@
 
   <PropertyGroup Condition="'$(Configuration)' != 'TravisCI'">
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MineCase.Engine/MineCase.Server.Engine.csproj
+++ b/src/MineCase.Engine/MineCase.Server.Engine.csproj
@@ -8,6 +8,8 @@
     <RootNamespace>MineCase.Engine</RootNamespace>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
     <DefineConstants>$(DefineConstants);ECS_SERVER</DefineConstants>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MineCase.Gateway/MineCase.Gateway.csproj
+++ b/src/MineCase.Gateway/MineCase.Gateway.csproj
@@ -6,6 +6,8 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MineCase.Nbt/MineCase.Nbt.csproj
+++ b/src/MineCase.Nbt/MineCase.Nbt.csproj
@@ -4,6 +4,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'TravisCI'">
@@ -12,11 +14,6 @@
 
   <PropertyGroup Condition="'$(Configuration)' != 'TravisCI'">
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MineCase.Protocol/MineCase.Protocol.csproj
+++ b/src/MineCase.Protocol/MineCase.Protocol.csproj
@@ -7,6 +7,8 @@
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <LangVersion>latest</LangVersion>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'TravisCI'">
@@ -15,11 +17,6 @@
 
   <PropertyGroup Condition="'$(Configuration)' != 'TravisCI'">
     <TargetFrameworks>netstandard2.0;net46</TargetFrameworks>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net46'">
-    <DebugType>full</DebugType>
-    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MineCase.Serialization/MineCase.Serialization.csproj
+++ b/src/MineCase.Serialization/MineCase.Serialization.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/MineCase.Server.Grains/MineCase.Server.Grains.csproj
+++ b/src/MineCase.Server.Grains/MineCase.Server.Grains.csproj
@@ -7,6 +7,8 @@
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MineCase.Server.Interfaces/MineCase.Server.Interfaces.csproj
+++ b/src/MineCase.Server.Interfaces/MineCase.Server.Interfaces.csproj
@@ -7,6 +7,8 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/MineCase.Server/MineCase.Server.csproj
+++ b/src/MineCase.Server/MineCase.Server.csproj
@@ -6,6 +6,8 @@
     <ServerGarbageCollection>true</ServerGarbageCollection>
     <ConcurrentGarbageCollection>true</ConcurrentGarbageCollection>
     <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
@@ -36,7 +38,7 @@
     <PackageReference Include="Microsoft.Orleans.Server" Version="2.0.0-beta1" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Numerics.Vectors" Version="4.4.0" />
-    <PackageReference Include="Orleans.Providers.MongoDB" Version="2.0.0-preview2"/>
+    <PackageReference Include="Orleans.Providers.MongoDB" Version="2.0.0-preview2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/UnitTest/MineCase.UnitTest.csproj
+++ b/tests/UnitTest/MineCase.UnitTest.csproj
@@ -2,8 +2,10 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
-	<CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
-	<Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <CodeAnalysisRuleSet>../../build/Analyzers.ruleset</CodeAnalysisRuleSet>
+    <Configurations>Debug;Release;Appveyor;TravisCI</Configurations>
+    <DebugType>full</DebugType>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,7 +21,7 @@
   <ItemGroup>
     <AdditionalFiles Include="..\..\build\stylecop.json" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\MineCase.Algorithm\MineCase.Algorithm.csproj" />
     <ProjectReference Include="..\..\src\MineCase.Engine\MineCase.Server.Engine.csproj" />


### PR DESCRIPTION
Opencover currently released doesn't support portable pdbs. (OpenCover/opencover#610).
So update all projects to use full pdbs.